### PR TITLE
Support Travis.ci and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: cpp
+
+sudo: required
+dist: bionic
+os: linux
+compiler: gcc
+
+install:
+  - |
+    wget http://kayari.org/gcc-latest/gcc-latest.deb && sudo dpkg -i gcc-latest.deb
+    export PATH=/opt/gcc-latest/bin:$PATH
+    export LD_RUN_PATH=/opt/gcc-latest/lib64
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh -disableMetrics
+    ./vcpkg integrate install
+    ./vcpkg install range-v3 fmt cairo harfbuzz freetype
+    cd ..
+
+before_script:
+  - gcov --version
+  - pip install --user cpp-coveralls
+
+after_success:
+  - coveralls --root . --include include --include src --include tests/unit_tests -E *doctest.v.* --gcov-options '\-lp'
+
+script:
+  - |
+    mkdir build
+    cd build
+    cmake ./.. -DENABLE_COVERAGE:BOOL=TRUE -DCMAKE_TOOLCHAIN_FILE=./../vcpkg/scripts/buildsystems/vcpkg.cmake
+    cmake --build . -- -j2
+    ./tests/unit_tests/unit_tests
+    cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 project(mfl)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## mathematical formula layout
 
-![](https://github.com/cpp-niel/mfl/workflows/continuous-integration/badge.svg)
+[![GitHub build](https://github.com/cpp-niel/mfl/workflows/continuous-integration/badge.svg)](https://github.com/cpp-niel/mfl/workflows/continuous-integration/badge.svg)
+[![Travis build](https://travis-ci.org/cpp-niel/mfl.svg?branch=master)](https://travis-ci.org/cpp-niel/mfl)
+[![Coverage Status](https://coveralls.io/repos/github/cpp-niel/mfl/badge.svg?branch=feature/travis_support)](https://coveralls.io/github/cpp-niel/mfl?branch=feature/travis_support)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/cpp-niel/mfl/blob/master/LICENSE)
 
 **A C++ library which computes the layout information for mathematical formulas provided


### PR DESCRIPTION
Add support for a Linux build using gcc on Travis. The build generates
coverage information that is then sent to coveralls.

Add badges for Travis and Coveralls to the readme.

Reduce the required CMake version so that we can use the default
CMake version on the Travis VMs.